### PR TITLE
Make every variable  a property of store object

### DIFF
--- a/scripts/store.js
+++ b/scripts/store.js
@@ -1,51 +1,55 @@
 import item from './item.js';
 
-const items = [];
-let hideCheckeditems = false;
+const store = {
+  items: [],
+  hideCheckeditems: false,
 
-const findById = function (id) {
-  return this.items.find(currentItem => currentItem.id === id);
-};
-
-const addItem = function (name) {
-  try {
-    item.validateName(name);
-    this.items.push(item.create(name));
-  } catch (e) {
-    console.log(e.message);
-  }
-};
-
-const findAndToggleChecked = function (id) {
-  const currentItem = this.findById(id);
-  currentItem.checked = !currentItem.checked;
-};
-
-const findAndUpdateName = function (id, name) {
-  try {
-    item.validateName(name);
+  findById: function (id) {
+    return this.items.find(currentItem => currentItem.id === id);
+  },
+  
+  
+  addItem: function (name) {
+    try {
+      item.validateName(name);
+      this.items.push(item.create(name));
+    } catch (e) {
+      console.log(e.message);
+    }
+  },
+  
+  findAndToggleChecked: function (id) {
     const currentItem = this.findById(id);
-    currentItem.name = name;
-  } catch (e) {
-    console.log('Cannot update name: ' + e.message);
-  }
+    currentItem.checked = !currentItem.checked;
+  },
+  
+  findAndUpdateName: function (id, name) {
+    try {
+      item.validateName(name);
+      const currentItem = this.findById(id);
+      currentItem.name = name;
+    } catch (e) {
+      console.log('Cannot update name: ' + e.message);
+    }
+  },
+  
+  findAndUpdateName: function (id, name) {
+    try {
+      item.validateName(name);
+      const currentItem = this.findById(id);
+      currentItem.name = name;
+    } catch (e) {
+      console.log('Cannot update name: ' + e.message);
+    }
+  },
+  
+  findAndDelete: function (id) {
+    this.items = this.items.filter(currentItem => currentItem.id !== id);
+  },
+  
+  toggleCheckedFilter: function () {
+    this.hideCheckedItems = !this.hideCheckedItems;
+  }  
 };
 
-const findAndDelete = function (id) {
-  this.items = this.items.filter(currentItem => currentItem.id !== id);
-};
-
-const toggleCheckedFilter = function () {
-  this.hideCheckedItems = !this.hideCheckedItems;
-};
-
-export default {
-  items,
-  hideCheckeditems,
-  findById,
-  addItem,
-  findAndToggleChecked,
-  findAndUpdateName,
-  findAndDelete,
-  toggleCheckedFilter
-};
+export default store;


### PR DESCRIPTION
Original implementation had `items` as a module-level variable accessible outside of  `this.items`.
References to `items` and `this.items` within store methods could end up referring to different arrays, particularly if any item was deleted (the delete method reassigned `this.items` but not `items`).

These issues would be avoided if students always referred to `this.items` instead of `items`, but we can expect them to mix them up specially since using `items` works. As a consequence of this change, referring to `items` within methods (or anywhere in this file) will *not* work, enforcing proper usage of `this.items`. Same applies to methods: they must be prefixed with `this.`.